### PR TITLE
FOS-880: Handle adding and removing sockets from the event loop safely.

### DIFF
--- a/src/zmqpp/loop.hpp
+++ b/src/zmqpp/loop.hpp
@@ -156,8 +156,10 @@ namespace zmqpp
         long tickless();
 
         poller poller_;
-        bool dispatching_;
+        bool dispatching_timers_;
+        bool dispatching_poller_;
         bool rebuild_poller_;
+        bool abort_poller_;
     };
 
 }

--- a/src/zmqpp/loop.hpp
+++ b/src/zmqpp/loop.hpp
@@ -129,11 +129,13 @@ namespace zmqpp
         typedef std::pair<std::unique_ptr<timer_t>, Callable> TimerItemCallablePair;
         static bool TimerItemCallablePairComp(const TimerItemCallablePair &lhs, const TimerItemCallablePair &rhs);
 
-        std::vector<PollItemCallablePair> items_;
+        /* Changing this to a std::list ensures that iterators are not invalidated during execution of
+         * start_handle_poller(). This allows pending events to be processed even if new events are added or removed
+         * during callback events. */
+        std::list<PollItemCallablePair> items_;
         std::list<TimerItemCallablePair> timers_;
-        std::vector<const socket_t *> sockRemoveLater_;
-        std::vector<raw_socket_t> fdRemoveLater_;
         std::vector<timer_id_t> timerRemoveLater_;
+        std::vector<raw_socket_t> fdRemoveLater_;
 
 
         void add(const zmq_pollitem_t &item, Callable callable);


### PR DESCRIPTION
This fix involves two changes:

* Storing the poll item pairs in a std::list
  This change ensures that poll item iterators are not invalidated
  during execution of start_handle_poller(). Using std::vector resulted
  in the occassional reallocation of memory which invalidated the
  iterators in the loop.

* No longer deferring removal of socket_t elements
  This change prevents access to references that would be invalid
  outside of the call to remove() avoiding SIGSEGV events.